### PR TITLE
Correction d'une erreur dans le guide iptables

### DIFF
--- a/guides/iptables-tutorial/chapters/tcp_ip_repetition.xml
+++ b/guides/iptables-tutorial/chapters/tcp_ip_repetition.xml
@@ -691,8 +691,8 @@ Ce champ contient des fanions mélangés appartenant
 à la fragmentation. Le premier bit est réservé, mais toujours inutilisé,
 et doit être placé à 0. Le second bit est placé à 0 si le paquet peut être
 fragmenté, et à 1 s'il ne peut pas être fragmenté. Le troisième et dernier
-bit peut être placé à 0 s'il était le dernier fragment, et à 1 s'il n'y a 
-pas de fragments supplémentaires de ce même paquet.
+bit peut être placé à 0 s'il était le dernier fragment, et à 1 s'il y a des
+fragments supplémentaires de ce même paquet.
       </para>
 
       <para>


### PR DESCRIPTION
Bonsoir,

Dans la section 2.3, l'explication des valeurs possibles du 3ème bit des fanions était erronée.
L'ancienne explication donnait la même signification au deux valeurs possibles.

Cordialement
