### PR TITLE
Changement de nom de colonne

### DIFF
--- a/travaux_pratiques/interco.inter-vlan.qa/interco.inter-vlan.qa.xml
+++ b/travaux_pratiques/interco.inter-vlan.qa/interco.inter-vlan.qa.xml
@@ -903,7 +903,7 @@ ipv4     2 tcp      6 113 TIME_WAIT<co xml:id='conntrack.state'/>  src=203.0.113
       <entry>Poste</entry>
       <entry>Rôle</entry>
       <entry>VLAN</entry>
-      <entry>Réseau</entry>
+      <entry>Adresse ip du poste</entry>
       </row>
     </thead>
     <tbody>
@@ -1050,7 +1050,7 @@ ipv4     2 tcp      6 113 TIME_WAIT<co xml:id='conntrack.state'/>  src=203.0.113
       <entry>Poste</entry>
       <entry>Rôle</entry>
       <entry>VLAN</entry>
-      <entry>Réseau</entry>
+      <entry>Adresse ip du poste</entry>
       </row>
     </thead>
     <tbody>


### PR DESCRIPTION
La colonne doit être appelée Adresse ip du poste et non réseau.
Quand on ne regarde pas la phrase du dessus, on se fait rapidement avoir sinon.